### PR TITLE
Timestamps to YYYY-MM-DD

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -145,9 +145,17 @@ class Runner:
             if self.name == "dcp_projectbbls":
                 df = self.timestamp_to_date(df, date_columns=["validated_date"])
             if self.name == "dcp_projects":
-                print(df.columns)
                 df = self.timestamp_to_date(
-                    df, date_columns=["completed_date", "certified_referred"]
+                    df,
+                    date_columns=[
+                        "completed_date",
+                        "certified_referred",
+                        "current_milestone_date",
+                        "current_envmilestone_date",
+                        "app_filed_date",
+                        "noticed_date",
+                        "approval_date",
+                    ],
                 )
 
         return df
@@ -162,7 +170,7 @@ class Runner:
         df[date_columns] = (
             df[date_columns]
             .apply(pd.to_datetime)
-            .apply(lambda x: x.dt.strftime("%Y-%M-%d"))
+            .apply(lambda x: x.dt.strftime("%Y-%m-%d"))
         )
         return df
 


### PR DESCRIPTION
The two visible datasets dcp_projects and dcp_projectbbls that are sent to edm-publishing each have one or more date fields. These date fields were converted from timestamp to YYYY-MM-DD. None of the data sent to big query or data library was changed in any way.

Originally I thought that the full dcp_projects and dcp_projectbbls datasets would be transformed in the same way but the visible and full versions of the data have different column labels. 