### PR TITLE
Pull dcp_validatedcommunitydistricts in dcp projects dataset 

### DIFF
--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -22,7 +22,7 @@ def make_open_data_table(sql_engine, dataset_name) -> None:
                 _dcp_applicant_customer_value as primary_applicant, 
                 dcp_applicanttype as dcp_applicanttype, 
                 dcp_borough as borough, 
-                dcp_validatedcitycouncildistricts as community_district,
+                dcp_validatedcommunitydistricts as community_district,
                 dcp_citycouncildistrict as cc_district, 
                 dcp_femafloodzonea as flood_zone_a,
                 dcp_femafloodzoneshadedx as flood_zone_shadedx, 


### PR DESCRIPTION
Changed the one field in the sql query and the code worked as expected. 

The values for community district look like 
<img width="550" alt="Screen Shot 2022-04-13 at 10 22 24 AM" src="https://user-images.githubusercontent.com/70385853/163202544-25ab6aa8-8dc6-429a-a606-7c734212cd1c.png">
 (there a bunch more value that got cut off). Flagging because this format of community district is unfamiliar to me. 