### PR TITLE
Recode numeric values

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -10,7 +10,7 @@ from . import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN, ZAP_ENGINE
 from .client import Client
 from .copy import psql_insert_copy
 from .pg import PG
-from .visible_projects import OPEN_DATA, make_open_data_table
+from .visible_projects import OPEN_DATA, make_open_data_table, open_data_recode
 
 
 class Runner:
@@ -97,7 +97,7 @@ class Runner:
     def open_data_cleaning(self, df):
         if self.name == "dcp_projects":  # To-do: figure out better design for this
             df["dcp_visibility"] = df["dcp_visibility"].str.split(".", expand=True)[0]
-            return df
+        df = open_data_recode(self.name, df, self.headers)
         return df
 
     def clean(self):

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -5,10 +5,11 @@ import requests
 OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
 
 
-metadata_link = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
-
+PICKLIST_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
+STATUS_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.StatusAttributeMetadata?$select=LogicalName&$expand=OptionSet"
 recode_fields = {
     "dcp_projects": [
+        "statuscode",
         "dcp_publicstatus",
         "dcp_ulurp_nonulurp",
         "dcp_ceqrtype",
@@ -103,12 +104,14 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     )
 
     # Get metadata
-    res = requests.get(metadata_link, headers=headers)
-    metadata = res.json()["value"]
+    metadata_values = []
+    for link in [PICKLIST_METADATA_LINK, STATUS_METADATA_LINK]:
+        res = requests.get(link, headers=headers)
+        metadata_values.extend(res.json()["value"])
 
     # Construct list of just fields we want to recode
     fields_to_recode = {}
-    for field in metadata:
+    for field in metadata_values:
         if field["LogicalName"] in fields_to_lookup:
             fields_to_recode[field["LogicalName"]] = field
 

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -7,7 +7,7 @@ OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
 
 PICKLIST_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
 STATUS_METADATA_LINK = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.StatusAttributeMetadata?$select=LogicalName&$expand=OptionSet"
-recode_fields = {
+RECODE_FIELDS = {
     "dcp_projects": [
         "statuscode",
         "dcp_publicstatus",
@@ -94,12 +94,12 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     if name == "dcp_projectbbls":
         fields_to_lookup = ["dcp_borough"]
     elif name == "dcp_projects":
-        fields_to_lookup = recode_fields[name]
+        fields_to_lookup = RECODE_FIELDS[name]
     else:
         raise f"no recode written for {name}"
 
     # Standardize integer representation
-    data[recode_fields[name]] = data[recode_fields[name]].apply(
+    data[RECODE_FIELDS[name]] = data[RECODE_FIELDS[name]].apply(
         func=lambda x: x.str.split(".").str[0], axis=1
     )
 
@@ -122,7 +122,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
                 "LocalizedLabels"
             ][0]["Label"]
         if name == "dcp_projectbbls":
-            for field in recode_fields[name]:
+            for field in RECODE_FIELDS[name]:
                 recoder[field] = field_recodes
         elif name == "dcp_projects":
             recoder[field_name] = field_recodes

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -1,4 +1,25 @@
+from typing import Dict
+import pandas as pd
+import requests
+
 OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
+
+
+metadata_link = "https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/EntityDefinitions(LogicalName='dcp_project')/Attributes/Microsoft.Dynamics.CRM.PicklistAttributeMetadata?$select=LogicalName&$expand=OptionSet"
+
+recode_fields = {
+    "dcp_projects": [
+        "dcp_publicstatus",
+        "dcp_ulurp_nonulurp",
+        "dcp_ceqrtype",
+        "dcp_easeis",
+        "dcp_applicanttype",
+        "dcp_borough",
+        "dcp_citycouncildistrict",
+        "dcp_mihmappedbutnotproposed",
+    ],
+    "dcp_projectbbls": ["dcp_validatedborough", "dcp_userinputborough"],
+}
 
 
 def make_open_data_table(sql_engine, dataset_name) -> None:
@@ -63,3 +84,45 @@ def make_open_data_table(sql_engine, dataset_name) -> None:
             on SUBSTRING(dcp_projectbbls.dcp_name, 0,10) = dcp_projects_visible.project_id);
             COMMIT;"""
         )
+
+
+def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFrame:
+
+    recoder = {}
+
+    if name == "dcp_projectbbls":
+        fields_to_lookup = ["dcp_borough"]
+    elif name == "dcp_projects":
+        fields_to_lookup = recode_fields[name]
+    else:
+        raise f"no recode written for {name}"
+
+    # Standardize integer representation
+    data[recode_fields[name]] = data[recode_fields[name]].apply(
+        func=lambda x: x.str.split(".").str[0], axis=1
+    )
+
+    # Get metadata
+    res = requests.get(metadata_link, headers=headers)
+    metadata = res.json()["value"]
+
+    # Construct list of just fields we want to recode
+    fields_to_recode = {}
+    for field in metadata:
+        if field["LogicalName"] in fields_to_lookup:
+            fields_to_recode[field["LogicalName"]] = field
+
+    for field_name, field_metadata in fields_to_recode.items():
+        field_recodes = {}
+        for category in field_metadata["OptionSet"]["Options"]:
+            field_recodes[str(category["Value"])] = category["Label"][
+                "LocalizedLabels"
+            ][0]["Label"]
+        if name == "dcp_projectbbls":
+            for field in recode_fields[name]:
+                recoder[field] = field_recodes
+        elif name == "dcp_projects":
+            recoder[field_name] = field_recodes
+
+    data.replace(to_replace=recoder, inplace=True)
+    return data


### PR DESCRIPTION
## Recode categorical data from integer representation to human-readable
Some categorical data is stored in the CRM as an integer representation. These integers are usually nine digits starting with a 7 but aren't always. The mapping from the integer representation to human-readable labels can be accessed via the API. 

This change was only made for the open data. There are 9 fields recoded in `dcp_projects` and 2 in `dcp_projectbbls`. The full list of columns recoded can be found in the `RECODE_FIELDS` constant in `src/visible_projects.py`. 

The two datasets are recoded with slightly different processes. For dcp_projects there is one "lookup" for each field in the dataset to get the int -> str mapping from the CRM. For dcp_projectbbls both columns to be converted are borough and thus use the same mapping, so only one int -> str dictionary is pulled from the metadata.

All fields can be found the metadata returned by `PICKLIST_METADATA_LINK` except for `projectstatus` which comes from `STATUS_METADATA_LINK`. Both links produce data in the same format so it's simple to iterate through the links, construct a list of metadata from both sources, and look up the fields to recode one by one from there.
