### PR TITLE
Only recode open data

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -76,7 +76,8 @@ class Runner:
             with open(f"{self.output_dir}/{_file}") as f:
                 data = json.load(f)
             df = pd.DataFrame(data["value"], dtype=str)
-            df = self.open_data_cleaning(df)
+            if self.open_dataset:
+                df = self.open_data_cleaning(df)
             df.to_sql(
                 name=self.name,
                 con=self.engine,


### PR DESCRIPTION
I tested that the recode worked for the two open data sets, but I didn't check the other five. Fixed the issue with an `if` statement.
Here is link to github action running the new code https://github.com/NYCPlanning/db-zap-opendata/actions/runs/2246769968