### PR TITLE
Recode ID Values from CRM

### DIFF
--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Install Dependencies
         run: python3 -m pip install .
 
-      - name: Get ${{ matrix.entity }}
-        run: python3 -m src.runner ${{ matrix.entity }}
+      - name: Get ${{ github.event.inputs.dataset }}
+        run: python3 -m src.runner ${{ github.event.inputs.dataset }}
 
       - name: Set Version info
         id: version
@@ -46,7 +46,7 @@ jobs:
           chmod +x mc
           sudo mv ./mc /usr/bin
           mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
-          
+
       - name: Export open data to edm-publishing
         env:
           VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -51,7 +51,4 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if ${{ matrix.open }};
-          then
-          ./zap.sh upload_do ${{ matrix.entity }} $VERSION
-          fi
+          ./zap.sh upload_do ${{  github.event.inputs.dataset }} $VERSION

--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.9"
-<<<<<<< HEAD
 
       - name: Install Dependencies
         run: python3 -m pip install .
@@ -53,5 +52,3 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           ./zap.sh upload_do ${{  github.event.inputs.dataset }} $VERSION
-=======
->>>>>>> main

--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -1,0 +1,57 @@
+name: Export Single Dataset
+
+on:
+  workflow_dispatch:
+    inputs:
+        dataset:
+          description: 'Name of the dataset'
+          required: true
+          default: dcp_projects
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    env:
+      CLIENT_ID: ${{ secrets.CLIENT_ID }}
+      SECRET: ${{ secrets.SECRET }}
+      TENANT_ID: ${{ secrets.TENANT_ID }}
+      ZAP_DOMAIN: ${{ secrets.ZAP_DOMAIN }}
+      ZAP_ENGINE: ${{ secrets.ZAP_ENGINE }}
+      AWS_S3_ENDPOINT: ${{ secrets.DO_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.DO_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.DO_SECRET_ACCESS_KEY }}
+      AWS_S3_LIBRARY_BUCKET: edm-recipes
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - name: Install Dependencies
+        run: python3 -m pip install .
+
+      - name: Get ${{ matrix.entity }}
+        run: python3 -m src.runner ${{ matrix.entity }}
+
+      - name: Set Version info
+        id: version
+        run: |
+          DATE=$(date +%Y%m%d)
+          echo "::set-output name=version::$DATE"
+
+      - name: Set up Mini IO
+        run: |
+          curl -O https://dl.min.io/client/mc/release/linux-amd64/mc
+          chmod +x mc
+          sudo mv ./mc /usr/bin
+          mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+          
+      - name: Export open data to edm-publishing
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if ${{ matrix.open }};
+          then
+          ./zap.sh upload_do ${{ matrix.entity }} $VERSION
+          fi

--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install Dependencies
         run: python3 -m pip install .
 
-      - name: Get ${{ github.event.inputs.dataset }}
-        run: python3 -m src.runner ${{ github.event.inputs.dataset }}
-
       - name: Set Version info
         id: version
         run: |
@@ -46,6 +43,9 @@ jobs:
           chmod +x mc
           sudo mv ./mc /usr/bin
           mc config host add spaces $AWS_S3_ENDPOINT $AWS_ACCESS_KEY_ID $AWS_SECRET_ACCESS_KEY --api S3v4
+
+      - name: Get ${{ github.event.inputs.dataset }}
+        run: python3 -m src.runner ${{ github.event.inputs.dataset }}
 
       - name: Export open data to edm-publishing
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -131,6 +131,7 @@ dmypy.json
 .env
 
 /.output
+.logs
 
 # MacOS automatically generated 
 .DS_Store

--- a/src/recode.py
+++ b/src/recode.py
@@ -200,7 +200,6 @@ def convert_to_human_readable(
             field_dict[metadata_hr_key] != id_val
         ):
             message = f"Mismatch between {field_dict[metadata_id_key]}/{field_dict[metadata_hr_key]} and {id_val} for field {local_fieldname}"
-            # raise Exception( message)
             logger.info(message)
 
         logger.info(f"assinging {human_readable} to field {local_fieldname}")

--- a/src/recode.py
+++ b/src/recode.py
@@ -1,0 +1,213 @@
+import json
+import logging
+from typing import List
+import pandas as pd
+import requests
+from .client import Client
+
+from .util import create_logger
+from . import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN, ZAP_ENGINE
+
+
+def get_headers():
+    client = Client(
+        zap_domain=ZAP_DOMAIN,
+        tenant_id=TENANT_ID,
+        client_id=CLIENT_ID,
+        secret=SECRET,
+    )
+    return client.request_header
+
+
+class RecodeTracker:
+    def __init__(self) -> None:
+        self.recode_fields = [
+            "primary_applicant",
+            "ceqr_leadagency",
+            "current_milestone",
+            "current_envmilestone",
+        ]
+        self.primary_applicant = {}
+        self.ceqr_leadagency = {}
+        self.current_milestone = {}
+        self.current_envmilestone = {}
+        self.logger = create_logger("Recode Logger", "reused_summary.log")
+        self.reused_recodings = {f: 0 for f in self.recode_fields}
+        self.total_records_recoded = 0
+        self.count_unseen_ID = 0
+
+    def new_recode(self, field: str, mapping: dict):
+        self.__getattribute__(field).update(mapping)
+
+    def find_recode(self, row):
+        new_ID = False
+        self.total_records_recoded += 1
+        for field in self.recode_fields:
+            value = row[field]
+            if value is not None:
+                if value in self.__getattribute__(field).keys():
+                    row[field] = self.__getattribute__(field)[value]
+                    self.reused_recodings[field] += 1
+                else:
+                    self.count_unseen_ID += 1
+                    new_ID = True
+        return new_ID, row
+
+
+class AuthRefresher:
+    """Serve fresh headers after 401"""
+
+    def __init__(self):
+        self.headers = get_headers()
+        self.logger = create_logger(
+            "Authorization Refresher Logger", "auth_refresher.log"
+        )
+
+    def refresh_headers(self):
+        self.headers = get_headers()
+        self.logger.info("Got new headers")
+
+
+def recode_id(data, debug_rows=False):
+    """Recode unique ID's from the CRM to human-readable"""
+    recode_logger = create_logger("Recode Logger", "recode_logger.log")
+    auth_refresher = AuthRefresher()
+    if debug_rows:
+        data = data.sample(debug_rows)
+    recode_tracker = RecodeTracker()
+    cleaned = data.apply(
+        axis=1,
+        func=recode_single_project,
+        args=(auth_refresher, recode_tracker, recode_logger),
+    )
+    recode_tracker.logger.info(
+        f"Records that had any ID value recoded: {recode_tracker.total_records_recoded} out of {cleaned.shape[0]}"
+    )
+    recode_tracker.logger.info(
+        f"Where existing recode could be used: {recode_tracker.reused_recodings}"
+    )
+    recode_tracker.logger.info(
+        f"Number of records with new ID for which URL had to be hit {recode_tracker.count_unseen_ID}"
+    )
+    cleaned.drop(columns=["crm_project_id"], inplace=True)
+    return cleaned
+
+
+def recode_single_project(
+    row: pd.Series,
+    auth: AuthRefresher,
+    recode_tracker: RecodeTracker,
+    logger: logging.Logger,
+):
+
+    additional_recode, row = recode_tracker.find_recode(row)
+    if additional_recode:
+        logger.info(f"Hitting URL for row {row.name}")
+    else:
+        logger.info(f"No additional recode needed for row {row.name}")
+    if additional_recode:
+        url = expand_url(row.crm_project_id)
+        res = requests.get(url, headers=auth.headers)
+        if res.status_code != 200:
+            auth.refresh_headers()
+            res = requests.get(url, headers=auth.headers)
+            if res.status_code != 200:
+                print(f"broken url {url} produced {res.status_code=}")
+                return row
+        expanded_project_data = res.json()
+        # Potential upgrade: return field instead of entire row
+        row = convert_to_human_readable(
+            expanded=expanded_project_data,
+            row=row,
+            local_fieldname="primary_applicant",
+            metadata_field_names=[
+                "dcp_applicant_customer_account",
+                "dcp_applicant_customer_contact",
+            ],
+            metadata_keys={
+                "dcp_applicant_customer_account": ("name", "accountid"),
+                "dcp_applicant_customer_contact": ("fullname", "contactid"),
+            },
+            recode_tracker=recode_tracker,
+            logger=logger,
+        )
+        row = convert_to_human_readable(
+            expanded=expanded_project_data,
+            row=row,
+            local_fieldname="current_milestone",
+            metadata_field_names=["dcp_CurrentMilestone"],
+            metadata_keys={
+                "dcp_CurrentMilestone": ("dcp_name", "dcp_projectmilestoneid")
+            },
+            recode_tracker=recode_tracker,
+            logger=logger,
+        )
+        row = convert_to_human_readable(
+            expanded=expanded_project_data,
+            row=row,
+            local_fieldname="current_envmilestone",
+            metadata_field_names=["dcp_currentenvironmentmilestone"],
+            metadata_keys={
+                "dcp_currentenvironmentmilestone": (
+                    "dcp_name",
+                    "dcp_projectmilestoneid",
+                )
+            },
+            recode_tracker=recode_tracker,
+            logger=logger,
+        )
+        row = convert_to_human_readable(
+            expanded=expanded_project_data,
+            row=row,
+            local_fieldname="ceqr_leadagency",
+            metadata_field_names=["dcp_leadagencyforenvreview"],
+            metadata_keys={"dcp_leadagencyforenvreview": ("name", "accountid")},
+            recode_tracker=recode_tracker,
+            logger=logger,
+        )
+    return row
+
+
+def convert_to_human_readable(
+    expanded: dict,
+    row: pd.Series,
+    local_fieldname: str,
+    metadata_field_names: List[str],
+    metadata_keys: dict,
+    recode_tracker: RecodeTracker,
+    logger=logging.Logger,
+):
+    id_val = row[local_fieldname]
+    logger.info(
+        f"Recoding record {row.name}: field {local_fieldname} has id of {id_val}"
+    )
+    field_dict = None
+    while metadata_field_names and field_dict is None:
+        metadata_field = metadata_field_names.pop()
+        field_dict = expanded[metadata_field]
+    metadata_hr_key, metadata_id_key = (
+        metadata_keys[metadata_field][0],
+        metadata_keys[metadata_field][1],
+    )
+    if field_dict is None:
+        if id_val is not None:
+            raise Exception(
+                f"data has {local_fieldname} of {id_val} but expanded of {json.dumps(expanded, indent=2)}"
+            )
+    else:
+        human_readable = field_dict[metadata_hr_key]
+        if (field_dict[metadata_id_key] != id_val) and (
+            field_dict[metadata_hr_key] != id_val
+        ):
+            message = f"Mismatch between {field_dict[metadata_id_key]}/{field_dict[metadata_hr_key]} and {id_val} for field {local_fieldname}"
+            # raise Exception( message)
+            logger.info(message)
+
+        logger.info(f"assinging {human_readable} to field {local_fieldname}")
+        row[local_fieldname] = human_readable
+        recode_tracker.new_recode(local_fieldname, {id_val: human_readable})
+    return row
+
+
+def expand_url(project_id):
+    return f"https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/dcp_projects({project_id})?$select=_dcp_applicant_customer_value,_dcp_currentmilestone_value,dcp_name&$expand=dcp_CurrentMilestone($select=dcp_name),dcp_leadagencyforenvreview($select=name),dcp_applicant_customer_contact($select=fullname),dcp_currentenvironmentmilestone($select=dcp_name),dcp_applicant_customer_account($select=name)"

--- a/src/recode_id.py
+++ b/src/recode_id.py
@@ -101,7 +101,7 @@ class AuthRefresher:
         self.logger.info("Got new headers")
 
 
-def recode_id(data, debug_rows=False):
+def recode_id(data, debug_rows: int = False):
     """Recode unique ID's from the CRM to human-readable"""
     recode_logger = create_logger("Recode Logger", "recode_logger.log")
     auth_refresher = AuthRefresher()

--- a/src/recode_id.py
+++ b/src/recode_id.py
@@ -202,7 +202,7 @@ def convert_to_human_readable(
             message = f"Mismatch between {field_dict[metadata_id_key]}/{field_dict[metadata_hr_key]} and {id_val} for field {local_fieldname}"
             logger.info(message)
 
-        logger.info(f"assinging {human_readable} to field {local_fieldname}")
+        logger.info(f"assigning {human_readable} to field {local_fieldname}")
 
         recode_tracker.new_recode(local_fieldname, {id_val: human_readable})
     return human_readable

--- a/src/recode_id.py
+++ b/src/recode_id.py
@@ -58,7 +58,7 @@ def get_headers():
     return client.request_header
 
 
-class RecodeTracker:
+class ReuseTracker:
     def __init__(self) -> None:
         self.primary_applicant = {}
         self.ceqr_leadagency = {}
@@ -108,7 +108,7 @@ def recode_id(data, debug_rows=False):
     if debug_rows:
         data = data.sample(debug_rows)
         data.index = [x for x in range(data.shape[0])]
-    recode_tracker = RecodeTracker()
+    recode_tracker = ReuseTracker()
     cleaned = data.apply(
         axis=1,
         func=recode_single_project,
@@ -130,7 +130,7 @@ def recode_id(data, debug_rows=False):
 def recode_single_project(
     row: pd.Series,
     auth: AuthRefresher,
-    recode_tracker: RecodeTracker,
+    recode_tracker: ReuseTracker,
     logger: logging.Logger,
 ):
 
@@ -165,7 +165,7 @@ def convert_to_human_readable(
     expanded: dict,
     row: pd.Series,
     local_fieldname: str,
-    recode_tracker: RecodeTracker,
+    recode_tracker: ReuseTracker,
     logger=logging.Logger,
     metadata_field_names: List[str] = None,
     metadata_keys: dict = None,

--- a/src/runner.py
+++ b/src/runner.py
@@ -146,6 +146,7 @@ class Runner:
             df = open_data_recode(self.name, df, self.headers)
             if self.name == "dcp_projectbbls":
                 df = self.timestamp_to_date(df, date_columns=["validated_date"])
+                df["project_id"] = df["project_id"].str.split(" ").str[0]
             if self.name == "dcp_projects":
                 df = self.timestamp_to_date(
                     df,

--- a/src/util.py
+++ b/src/util.py
@@ -1,0 +1,18 @@
+import logging
+import os
+
+
+def create_logger(logger_name, file_name) -> logging.Logger:
+    if not os.path.exists(".logs/"):
+        os.makedirs(".logs/")
+    logger = logging.getLogger(logger_name)
+    logger.setLevel(logging.DEBUG)
+
+    formatter = logging.Formatter("%(asctime)s:%(name)s: %(message)s")
+    logger.handlers = []
+    file_handler = logging.FileHandler(f".logs/{file_name}")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+    if not logger.hasHandlers():
+        logger.addHandler(file_handler)
+    return logger

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -107,10 +107,8 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     )
 
     # Get metadata
-    metadata_values = []
-    for link in [PICKLIST_METADATA_LINK, STATUS_METADATA_LINK]:
-        res = requests.get(link, headers=headers)
-        metadata_values.extend(res.json()["value"])
+
+    metadata_values = get_metadata(headers)
 
     # Construct list of just fields we want to recode
     fields_to_recode = {}
@@ -133,3 +131,11 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     print(recoder)
     data.replace(to_replace=recoder, inplace=True)
     return data
+
+
+def get_metadata(headers, metadata_values):
+    metadata_values = []
+    for link in [PICKLIST_METADATA_LINK, STATUS_METADATA_LINK]:
+        res = requests.get(link, headers=headers)
+        metadata_values.extend(res.json()["value"])
+    return metadata_values

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -126,7 +126,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
 
     if name == "dcp_projects":
         print(f"nrows in data passed to recode id {data.shape[0]}")
-        data = recode_id(data, headers, debug_rows=1000)
+        data = recode_id(data, headers)
         print(f"nrows in data return by recode id {data.shape[0]}")
 
     return data

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -1,6 +1,7 @@
-from typing import Dict
+from typing import Dict, List
 import pandas as pd
 import requests
+import json
 
 OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
 
@@ -31,6 +32,7 @@ def make_open_data_table(sql_engine, dataset_name) -> None:
         CREATE TABLE dcp_projects_visible as 
         (SELECT dcp_name as project_id,
                 dcp_projectname as project_name,
+                dcp_projectid as crm_project_id,
                 dcp_projectbrief as project_brief,
                 statuscode as project_status,
                 dcp_publicstatus as public_status,
@@ -91,15 +93,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
 
     recoder = {}
 
-    if name == "dcp_projectbbls":
-        fields_to_lookup = ["dcp_borough"]
-        fields_to_rename = RECODE_FIELDS[name]
-
-    elif name == "dcp_projects":
-        fields_to_lookup = [t[0] for t in RECODE_FIELDS[name]]
-        fields_to_rename = [t[1] for t in RECODE_FIELDS[name]]
-    else:
-        raise f"no recode written for {name}"
+    fields_to_lookup, fields_to_rename = get_fields(name)
 
     # Standardize integer representation
     data[fields_to_rename] = data[fields_to_rename].apply(
@@ -128,14 +122,120 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
             recoder["unverified_borough"] = field_recodes
         elif name == "dcp_projects":
             recoder[local_name] = field_recodes
-    print(recoder)
     data.replace(to_replace=recoder, inplace=True)
+
+    if name == "dcp_projects":
+        print(f"nrows in data passed to recode id {data.shape[0]}")
+        data = recode_id(data, headers, debug_rows=1000)
+        print(f"nrows in data return by recode id {data.shape[0]}")
+
     return data
 
 
-def get_metadata(headers, metadata_values):
+def get_fields(name):
+    if name == "dcp_projectbbls":
+        fields_to_lookup = ["dcp_borough"]
+        fields_to_rename = RECODE_FIELDS[name]
+
+    elif name == "dcp_projects":
+        fields_to_lookup = [t[0] for t in RECODE_FIELDS[name]]
+        fields_to_rename = [t[1] for t in RECODE_FIELDS[name]]
+    else:
+        raise f"no recode written for {name}"
+    return fields_to_lookup, fields_to_rename
+
+
+def recode_id(data, headers, debug_rows=False):
+    """Recode unique ID's from the CRM to human-readable"""
+    if debug_rows:
+        data = data.iloc[:debug_rows, :]
+    cleaned = data.apply(axis=1, func=recode_single_project, args=(headers,))
+    cleaned.drop(columns=["crm_project_id"], inplace=True)
+    return cleaned
+
+
+def recode_single_project(row, headers):
+    url = expand_url(row.crm_project_id)
+    res = requests.get(url, headers=headers)
+    if res.status_code != 200:
+        print(f"broken url {url} produced {res.status_code=}")
+    expanded_project_data = res.json()
+    row = convert_to_human_readable(
+        expanded=expanded_project_data,
+        row=row,
+        local_fieldname="primary_applicant",
+        metadata_field_names=[
+            "dcp_applicant_customer_account",
+            "dcp_applicant_customer_contact",
+        ],
+        metadata_keys={
+            "dcp_applicant_customer_account": ("name", "accountid"),
+            "dcp_applicant_customer_contact": ("fullname", "contactid"),
+        },
+    )
+    row = convert_to_human_readable(
+        expanded=expanded_project_data,
+        row=row,
+        local_fieldname="current_milestone",
+        metadata_field_names=["dcp_CurrentMilestone"],
+        metadata_keys={"dcp_CurrentMilestone": ("dcp_name", "dcp_projectmilestoneid")},
+    )
+    row = convert_to_human_readable(
+        expanded=expanded_project_data,
+        row=row,
+        local_fieldname="current_envmilestone",
+        metadata_field_names=["dcp_currentenvironmentmilestone"],
+        metadata_keys={
+            "dcp_currentenvironmentmilestone": ("dcp_name", "dcp_projectmilestoneid")
+        },
+    )
+    row = convert_to_human_readable(
+        expanded=expanded_project_data,
+        row=row,
+        local_fieldname="ceqr_leadagency",
+        metadata_field_names=["dcp_leadagencyforenvreview"],
+        metadata_keys={"dcp_leadagencyforenvreview": ("name", "accountid")},
+    )
+    return row
+
+
+def convert_to_human_readable(
+    expanded: dict,
+    row: pd.Series,
+    local_fieldname: str,
+    metadata_field_names: List[str],
+    metadata_keys: dict,
+):
+    field_dict = None
+    while metadata_field_names and field_dict is None:
+        metadata_field = metadata_field_names.pop()
+        field_dict = expanded[metadata_field]
+    metadata_hr_key, metadata_id_key = (
+        metadata_keys[metadata_field][0],
+        metadata_keys[metadata_field][1],
+    )
+    if field_dict is None:
+        if row[local_fieldname] is not None:
+            raise Exception(
+                f"data has {local_fieldname} of {row[local_fieldname]} but expanded of {json.dumps(expanded, indent=2)}"
+            )
+    else:
+        if field_dict[metadata_id_key] != row[local_fieldname]:
+            raise Exception(
+                f"Mismatch between {field_dict[metadata_id_key]} and {row[local_fieldname]}"
+            )
+
+        row[local_fieldname] = field_dict[metadata_hr_key]
+    return row
+
+
+def get_metadata(headers):
     metadata_values = []
     for link in [PICKLIST_METADATA_LINK, STATUS_METADATA_LINK]:
         res = requests.get(link, headers=headers)
         metadata_values.extend(res.json()["value"])
     return metadata_values
+
+
+def expand_url(project_id):
+    return f"https://nycdcppfs.crm9.dynamics.com/api/data/v9.1/dcp_projects({project_id})?$select=_dcp_applicant_customer_value,_dcp_currentmilestone_value,dcp_name&$expand=dcp_CurrentMilestone($select=dcp_name),dcp_leadagencyforenvreview($select=name),dcp_applicant_customer_contact($select=fullname),dcp_currentenvironmentmilestone($select=dcp_name),dcp_applicant_customer_account($select=name)"

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -125,9 +125,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     data.replace(to_replace=recoder, inplace=True)
 
     if name == "dcp_projects":
-        print(f"nrows in data passed to recode id {data.shape[0]}")
-        data = recode_id(data, headers, debug_rows=10 ** 3)
-        print(f"nrows in data return by recode id {data.shape[0]}")
+        data = recode_id(data)
 
     return data
 

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -1,7 +1,7 @@
 from typing import Dict
 import pandas as pd
 import requests
-from .recode import recode_id
+from .recode_id import recode_id
 
 OPEN_DATA = ["dcp_projects", "dcp_projectbbls"]
 


### PR DESCRIPTION
# Recode ID Values
This PR is to address issue #25 which was opened when Matt Croswell noticed that the open datasets sent to digital ocean had some fields still populated with non-human readable values. The issue is that there are two types of integer representation in the CRM. 
The first type is values like `717170000` that are placeholders for values that are re-used many times throughout the CRM. Matt has a list of the mappings this [this spreadsheet](https://nyco365.sharepoint.com/:x:/r/sites/NYCPLANNING/itd/edm/_layouts/15/Doc.aspx?sourcedoc=%7B31588592-8910-4FAD-B77C-0C62E106C794%7D&file=Attributes.Values.for.EDM_FullList.xlsx&action=default&mobileredirect=true), and the code to apply those mappings was merged in PR #19. The mappings can be downloaded from API from one single query. 
The second type of values to recode are what I've termed "ID values" which look like `0014e50f-1133-e811-8126-1458d04dc8c8`. These are different in that they aren't re-used nearly as much, and the mappings for a given record come from an API query specific to that record. These values are re-used, so `0014e50f-1133-e811-8126-1458d04dc8c8` will map to the same string in another record. However many records have at least one unique ID value and thus need a specific API query run to get back the mappings.

## New recode process

Lives in a new module called recode_id. There are four fields populated with these ID values, which are hardcoded into a constant in the top of the module. 

### Iterate through records and fields 
Most records need their own API call, so I iterate through each record with `.apply`. The rest of the logic is in `recode_single_project`, where the code first uses a `ReuseTracker` instance to check if the ID's present in the record have already been mapped. Sometimes each ID value has been seen already and can be mapped from the `ReuseTracker` attributes. But usually a new url for the API is generated and then the mappings converted to a dictionary from the json. I think taking a random record and seeing the mappings returned by the API is helpful to understand the code. 

### Re-use mapping with `ReuseTracker`
Due to long runtimes this class was implemented to track the mappings seen in earlier records. Each new ID value/human readable value pair is added to the corresponding dictionary and then used to recode if the ID value is seen again in a later record. 

### Get fresh headers
From my observation, it seems that the headers used to authorize the request can only be used a limited number of times before the API returns a 401 permission denied. In this situation there is code to get new headers and try again, and if this doesn't work then give up and row as is. 

## Logging process
Need logs as run-time are long and I want to get info about a run while it's going

## New Workflow
Wanted a workflow to test my new code. The new ` Export Single Dataset` action runs and exports a single open dataset to DO. It was modeled off of a similar "single dataset" action in data library

## Refactor to simplify
As I added new code I needed to refactor to keep things organized. I refactored code to new functions in `visible_projects.py` and moved my new recode ID code to a new module.

## Actions with new output
Export [dcp_projects](https://github.com/NYCPlanning/db-zap-opendata/runs/6779552446?check_suite_focus=true) and [dcp_projectbbls](https://github.com/NYCPlanning/db-zap-opendata/actions/runs/2456379897). Outputs should be [here](https://cloud.digitalocean.com/spaces/edm-publishing?i=266877&path=db-zap%2F20220607%2F) on digital ocean  

## Clean `project_id` field in project bbls dataset
This was the second thing Matt mentioned in the issue, fortunately much easier, one line change of 
```python
df["project_id"] = df["project_id"].str.split(" ").str[0]
```
in `src/runner.py`