### PR TITLE
Null Project Readiness Milestone and Date

### DIFF
--- a/src/runner.py
+++ b/src/runner.py
@@ -161,8 +161,8 @@ class Runner:
                         "approval_date",
                     ],
                 )
-                df.loc[df.current_milestone.contains("MM - Project Readiness"), "current_envmilestone_date"] = None
-                df.loc[df.current_milestone.contains("MM - Project Readiness"), "current_milestone"] = None
+                df.loc[df.current_milestone.str.contains("MM - Project Readiness"), "current_envmilestone_date"] = None
+                df.loc[df.current_milestone.str.contains("MM - Project Readiness"), "current_milestone"] = None
 
         return df
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -161,8 +161,8 @@ class Runner:
                         "approval_date",
                     ],
                 )
-                df.loc[df.current_milestone == "MM- Project Readiness", "current_envmilestone_date"] = None
-                df.loc[df.current_milestone == "MM- Project Readiness", "current_milestone"] = None
+                df.loc[df.current_milestone.contains("Project Readiness"), "current_envmilestone_date"] = None
+                df.loc[df.current_milestone.contains("Project Readiness"), "current_milestone"] = None
 
         return df
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -145,6 +145,7 @@ class Runner:
             )
         if open_data:
             df = open_data_recode(self.name, df, self.headers)
+            df.to_csv(f"{self.output_file}_after_recode.csv", index=False)
             if self.name == "dcp_projectbbls":
                 df = self.timestamp_to_date(df, date_columns=["validated_date"])
                 df["project_id"] = df["project_id"].str.split(" ").str[0]
@@ -161,9 +162,8 @@ class Runner:
                         "approval_date",
                     ],
                 )
-                df.loc[df.current_milestone.str.contains("MM - Project Readiness"), "current_envmilestone_date"] = None
-                df.loc[df.current_milestone.str.contains("MM - Project Readiness"), "current_milestone"] = None
-
+                df.loc[(~df.current_milestone.isnull()) & (df.current_milestone.str.contains("MM - Project Readiness")), "current_milestone_date"] = None
+                df.loc[(~df.current_milestone.isnull()) & (df.current_milestone.str.contains("MM - Project Readiness")), "current_milestone"] = None
         return df
 
     def __call__(self):

--- a/src/runner.py
+++ b/src/runner.py
@@ -99,7 +99,8 @@ class Runner:
     def open_data_cleaning(self, df):
         if self.name == "dcp_projects":  # To-do: figure out better design for this
             df["dcp_visibility"] = df["dcp_visibility"].str.split(".", expand=True)[0]
-
+            #df.loc[df._dcp_currentmilestone_value == "MM- Project Readiness", "dcp_currentmilestoneactualstartdate"] = None
+            #df.loc[df._dcp_currentmilestone_value == "MM- Project Readiness", "_dcp_currentmilestone_value"] = None
         return df
 
     def clean(self):
@@ -160,6 +161,8 @@ class Runner:
                         "approval_date",
                     ],
                 )
+                df.loc[df.current_milestone == "MM- Project Readiness", "current_envmilestone_date"] = None
+                df.loc[df.current_milestone == "MM- Project Readiness", "current_milestone"] = None
 
         return df
 

--- a/src/runner.py
+++ b/src/runner.py
@@ -99,8 +99,6 @@ class Runner:
     def open_data_cleaning(self, df):
         if self.name == "dcp_projects":  # To-do: figure out better design for this
             df["dcp_visibility"] = df["dcp_visibility"].str.split(".", expand=True)[0]
-            #df.loc[df._dcp_currentmilestone_value == "MM- Project Readiness", "dcp_currentmilestoneactualstartdate"] = None
-            #df.loc[df._dcp_currentmilestone_value == "MM- Project Readiness", "_dcp_currentmilestone_value"] = None
         return df
 
     def clean(self):

--- a/src/runner.py
+++ b/src/runner.py
@@ -38,7 +38,7 @@ class Runner:
          
 
     def download(self):
-        self.create_output_dir()
+        self.create_output_cache_dir()
         nextlink = f"{ZAP_DOMAIN}/api/data/v9.1/{self.name}"
         counter = 0
         while nextlink != "":

--- a/src/runner.py
+++ b/src/runner.py
@@ -24,14 +24,18 @@ class Runner:
         )
         self.name = name
         self.output_dir = f".output/{name}"
+        self.cache_dir = f".cache/{name}"
         self.output_file = f"{self.output_dir}/{self.name}"
         self.headers = self.c.request_header
         self.engine = PG(ZAP_ENGINE).engine
         self.open_dataset = self.name in OPEN_DATA
 
-    def create_output_dir(self):
+    def create_output_cache_dir(self):
         if not os.path.isdir(self.output_dir):
-            os.makedirs(self.output_dir, exist_ok=True)
+            os.makedirs(self.output_dir, exist_ok=True) 
+        if not os.path.isdir(self.cache_dir):
+            os.makedirs(self.cache_dir, exist_ok=True)
+         
 
     def download(self):
         self.create_output_dir()
@@ -143,7 +147,7 @@ class Runner:
             )
         if open_data:
             df = open_data_recode(self.name, df, self.headers)
-            df.to_csv(f"{self.output_file}_after_recode.csv", index=False)
+            df.to_csv(f"{self.cache_dir}/{self.name}_after_recode.csv", index=False)
             if self.name == "dcp_projectbbls":
                 df = self.timestamp_to_date(df, date_columns=["validated_date"])
                 df["project_id"] = df["project_id"].str.split(" ").str[0]

--- a/src/runner.py
+++ b/src/runner.py
@@ -161,8 +161,8 @@ class Runner:
                         "approval_date",
                     ],
                 )
-                df.loc[df.current_milestone.contains("Project Readiness"), "current_envmilestone_date"] = None
-                df.loc[df.current_milestone.contains("Project Readiness"), "current_milestone"] = None
+                df.loc[df.current_milestone.contains("MM - Project Readiness"), "current_envmilestone_date"] = None
+                df.loc[df.current_milestone.contains("MM - Project Readiness"), "current_milestone"] = None
 
         return df
 

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -125,7 +125,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     data.replace(to_replace=recoder, inplace=True)
 
     if name == "dcp_projects":
-        data = recode_id(data)
+        data = recode_id(data, 1000)
 
     return data
 

--- a/src/visible_projects.py
+++ b/src/visible_projects.py
@@ -125,7 +125,7 @@ def open_data_recode(name: str, data: pd.DataFrame, headers: Dict) -> pd.DataFra
     data.replace(to_replace=recoder, inplace=True)
 
     if name == "dcp_projects":
-        data = recode_id(data, 1000)
+        data = recode_id(data)
 
     return data
 


### PR DESCRIPTION
for #31  

## Overview
Null the `current_milestone` and `current_milestone_date` MM - project readiness when the . The script is straightforward even though might not seem most elegant because a more strict string matching e.g. == "MM - Project Readiness" do not work due to random whitespaces around the text and `.contains` requires not null matching which logic I ended up using . 

## {self.output_file}_after_recode.csv
I found writing out a output after the recoding is finished is convenient for local development and because it is most time consuming part of the testing process and useful when debugging open data related things because otherwise the intermediate field values from the postgres db will be not human readables. 

## Review Suggestion
Since recreate the results locally is time consuming with the recoding process. I recommend comparing csv output from [the new run after this change is implemented](https://nyc3.digitaloceanspaces.com/edm-publishing/db-zap/20220721/dcp_projects/dcp_projects.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=PKZA5BU5V6QRTZBPHETD%2F20220721%2Fnyc3%2Fs3%2Faws4_request&X-Amz-Date=20220721T154218Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=145cb177006201f2c3d5e79f72569568fecfccaf7636de8f20d84ea2a3e3dda4) and [a previous run without the change](https://nyc3.digitaloceanspaces.com/edm-publishing/db-zap/20220718/dcp_projects/dcp_projects.csv?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=PKZA5BU5V6QRTZBPHETD%2F20220721%2Fnyc3%2Fs3%2Faws4_request&X-Amz-Date=20220721T155143Z&X-Amz-Expires=86400&X-Amz-SignedHeaders=host&X-Amz-Signature=3f6895e5e7628b23c1f21271201831fe5896696404d0993e12cc9277cc592b04). There are only a handful records (e.g. 2020Q0130) for MM - Project Readiness so should be easy to check by hand for all of them.