### PR TITLE
fix weekly export action

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -32,6 +32,5 @@
 	"initializeCommand": "${localWorkspaceFolder}/.devcontainer/initializeCommand.sh",
     "runArgs": [
         "--env-file", "${localWorkspaceFolder}/.devcontainer/.env"
-    ], 
-	"remoteUser": "vscode"
+    ]
 }

--- a/.devcontainer/example.env
+++ b/.devcontainer/example.env
@@ -2,4 +2,4 @@ TENANT_ID=XXXXXXXXXXXXXXXXXXXX
 ZAP_DOMAIN=https://{{organization}}.{{crm}}.dynamics.com
 CLIENT_ID=XXXXX-XXXXXX-XXXX-XXXXXXX
 SECRET=XXXXX-XXXXXX-XXXX-XXXXXXX
-ZAP_ENGINE=postgresql://username:password@host:port/database
+ZAP_ENGINE=XXXX

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -31,8 +31,8 @@ jobs:
         # open:
         #   - false
         include:
-          - entity: "dcp_projects"
-            open: true
+          # - entity: "dcp_projects"
+          #   open: true
           - entity: "dcp_projectbbls"
             open: true
 

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -73,14 +73,12 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: ./zap.sh upload_bq ${{ matrix.entity }} $VERSION
 
-      - name: Archive recoded upload_recoded_bq to BigQuery
+      - name: Archive recoded data to BigQuery
         env:
           VERSION: ${{ steps.version.outputs.version }}
+        if: ${{ matrix.open }}
         run: |
-          if ${{ matrix.open }};
-          then
           ./zap.sh upload_recoded_bq ${{ matrix.entity }} $VERSION
-          fi
 
       - name: Archive to data library - PGdump
         env:

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Archive recoded upload_recoded_bq to BigQuery
         env:
           VERSION: ${{ steps.version.outputs.version }}
-        run: 
+        run: |
           if ${{ matrix.open }};
           then
           ./zap.sh upload_recoded_bq ${{ matrix.entity }} $VERSION

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -22,14 +22,14 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        entity:
-          - dcp_projectactions
-          - dcp_projectmilestones
-          - dcp_projectactionbbls
-          - dcp_communityboarddispositions
-          - dcp_dcpprojectteams
-        open:
-          - false
+        # entity:
+        #   - dcp_projectactions
+        #   - dcp_projectmilestones
+        #   - dcp_projectactionbbls
+        #   - dcp_communityboarddispositions
+        #   - dcp_dcpprojectteams
+        # open:
+        #   - false
         include:
           - entity: "dcp_projects"
             open: true

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -22,17 +22,17 @@ jobs:
       fail-fast: false
       max-parallel: 1
       matrix:
-        # entity:
-        #   - dcp_projectactions
-        #   - dcp_projectmilestones
-        #   - dcp_projectactionbbls
-        #   - dcp_communityboarddispositions
-        #   - dcp_dcpprojectteams
-        # open:
-        #   - false
+        entity:
+          - dcp_projectactions
+          - dcp_projectmilestones
+          - dcp_projectactionbbls
+          - dcp_communityboarddispositions
+          - dcp_dcpprojectteams
+        open:
+          - false
         include:
-          # - entity: "dcp_projects"
-          #   open: true
+          - entity: "dcp_projects"
+            open: true
           - entity: "dcp_projectbbls"
             open: true
 

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -52,7 +52,7 @@ jobs:
         id: version
         run: |
           DATE=$(date +%Y%m%d)
-          echo "version=::$DATE" >> "$GITHUB_OUTPUT"
+          echo "version=$DATE" >> "$GITHUB_OUTPUT"
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0

--- a/.github/workflows/export.yml
+++ b/.github/workflows/export.yml
@@ -73,6 +73,15 @@ jobs:
           VERSION: ${{ steps.version.outputs.version }}
         run: ./zap.sh upload_bq ${{ matrix.entity }} $VERSION
 
+      - name: Archive recoded upload_recoded_bq to BigQuery
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: 
+          if ${{ matrix.open }};
+          then
+          ./zap.sh upload_recoded_bq ${{ matrix.entity }} $VERSION
+          fi
+
       - name: Archive to data library - PGdump
         env:
           VERSION: ${{ steps.version.outputs.version }}

--- a/.github/workflows/single_visible.yml
+++ b/.github/workflows/single_visible.yml
@@ -40,7 +40,7 @@ jobs:
         id: version
         run: |
           DATE=$(date +%Y%m%d)
-          echo "version=::$DATE" >> "$GITHUB_OUTPUT"
+          echo "version=$DATE" >> "$GITHUB_OUTPUT"
 
       - name: Set up Mini IO
         run: |

--- a/src/runner.py
+++ b/src/runner.py
@@ -172,9 +172,13 @@ class Runner:
         return df
 
     def __call__(self):
+        print("~~~ RUNNING clean ~~~")
         self.clean()
+        print("~~~ RUNNING download ~~~")
         self.download()
+        print("~~~ RUNNING combine ~~~")
         self.combine()
+        print("~~~ RUNNING export ~~~")
         self.export()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,12 +3,15 @@ from src import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN
 from src.client import Client
 
 
+@pytest.fixture
 def test_data_path():
+    """Return the test data directory path string"""
     return "tests/test_data"
 
 
 @pytest.fixture(scope="session")
 def test_client():
+    """Return a :class:`src.client.Client` instance for the test session."""
     return Client(
         zap_domain=ZAP_DOMAIN,
         tenant_id=TENANT_ID,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,11 @@ import pytest
 from src import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN
 from src.client import Client
 
-TEST_DATA_PATH = "tests/test_data"
 
-@pytest.fixture()
-def seed_data_path():
-    return "mapzap/seeds"
+@pytest.fixture(scope="session")
+def test_data_path():
+    return "tests/test_data"
+
 
 @pytest.fixture(scope="session")
 def test_client():

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+from src import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN
+from src.client import Client
+
+TEST_DATA_PATH = "tests/test_data"
+
+@pytest.fixture()
+def seed_data_path():
+    return "mapzap/seeds"
+
+@pytest.fixture(scope="session")
+def test_client():
+    return Client(
+        zap_domain=ZAP_DOMAIN,
+        tenant_id=TENANT_ID,
+        client_id=CLIENT_ID,
+        secret=SECRET,
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ from src import CLIENT_ID, SECRET, TENANT_ID, ZAP_DOMAIN
 from src.client import Client
 
 
-@pytest.fixture(scope="session")
 def test_data_path():
     return "tests/test_data"
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,0 +1,6 @@
+def test_access_token(test_client):
+    assert isinstance(test_client.access_token, str)
+
+
+def test_request_header(test_client):
+    assert isinstance(test_client.request_header, dict)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,8 @@
 import pandas as pd
 from src.util import timestamp_to_date
 
-TEST_DATA_PATH = "tests/test_data"
-
-def test_timestamp_to_date():
-    data = pd.read_csv(f"{TEST_DATA_PATH}/timestamp_data.csv")
+def test_timestamp_to_date(test_data_path):
+    data = pd.read_csv(f"{test_data_path}/timestamp_data.csv")
     data_dates = timestamp_to_date(data, date_columns=["date_column_a"])
 
     assert data_dates["date_column_a"].equals(data_dates["date_column_a_expected"])

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,6 +1,7 @@
 import pandas as pd
 from src.util import timestamp_to_date
 
+
 def test_timestamp_to_date(test_data_path):
     data = pd.read_csv(f"{test_data_path}/timestamp_data.csv")
     data_dates = timestamp_to_date(data, date_columns=["date_column_a"])

--- a/tests/test_visible_projects.py
+++ b/tests/test_visible_projects.py
@@ -1,0 +1,68 @@
+import pytest
+import pprint
+import pandas as pd
+from src.visible_projects import get_fields, get_metadata
+
+# dict_printer = pprint.PrettyPrinter(width=20)
+dict_printer = pprint.PrettyPrinter(indent=4)
+
+
+@pytest.fixture(scope="module")
+def metadata_values(test_client):
+    headers = test_client.request_header
+    return get_metadata(headers)
+
+
+@pytest.fixture(scope="module")
+def fields_in_metadata(metadata_values):
+    return [field["LogicalName"] for field in metadata_values]
+
+
+@pytest.fixture(scope="module")
+def fields_in_metadata(metadata_values):
+    return [field["LogicalName"] for field in metadata_values]
+
+
+@pytest.fixture(scope="module")
+def all_fields_metadata(metadata_values):
+    return {field["LogicalName"]: field for field in metadata_values}
+
+
+def test_get_metadata(metadata_values):
+    assert isinstance(metadata_values, list)
+
+
+@pytest.mark.parametrize("dataset_name", ["dcp_projects", "dcp_projectbbls"])
+def test_recode_fields(fields_in_metadata, dataset_name):
+    fields_to_lookup, _ = get_fields(dataset_name)
+
+    for field in fields_to_lookup:
+        assert field in fields_in_metadata
+
+
+def test_recode_fields_raise(fields_in_metadata):
+    fields_to_lookup, _ = (["bad_field"], ["bad_field_rename"])
+
+    with pytest.raises(AssertionError):
+        for field in fields_to_lookup:
+            assert field in fields_in_metadata
+
+
+def test_crm_codes(seed_data_path):
+    crm_codes = pd.read_csv(f"{seed_data_path}/seed_crm_codes.csv")
+
+@pytest.mark.parametrize("dataset_name", ["dcp_projects", "dcp_projectbbls"])
+def test_recode_values(all_fields_metadata, dataset_name):
+    fields_to_lookup, _ = get_fields(dataset_name)
+# def test_recode_values(all_fields_metadata):
+#     fields_to_lookup, _ = (["dcp_applicanttype"], ["applicant_type"])
+
+    for field in fields_to_lookup:
+        print(f"\n\nField name: {field}")
+        field_categories = all_fields_metadata[field]["OptionSet"]["Options"]
+        for category in field_categories:
+            print(f"CATEGORY")
+            crm_code = category["Value"]
+            zap_value = category["Label"]["LocalizedLabels"][0]["Label"]
+            print(f"\t{crm_code}")
+            print(f"\t{zap_value}")

--- a/tests/test_visible_projects.py
+++ b/tests/test_visible_projects.py
@@ -1,10 +1,5 @@
 import pytest
-import pprint
-import pandas as pd
 from src.visible_projects import get_fields, get_metadata
-
-# dict_printer = pprint.PrettyPrinter(width=20)
-dict_printer = pprint.PrettyPrinter(indent=4)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_visible_projects.py
+++ b/tests/test_visible_projects.py
@@ -14,11 +14,6 @@ def fields_in_metadata(metadata_values):
 
 
 @pytest.fixture(scope="module")
-def fields_in_metadata(metadata_values):
-    return [field["LogicalName"] for field in metadata_values]
-
-
-@pytest.fixture(scope="module")
 def all_fields_metadata(metadata_values):
     return {field["LogicalName"]: field for field in metadata_values}
 

--- a/tests/test_visible_projects.py
+++ b/tests/test_visible_projects.py
@@ -48,14 +48,10 @@ def test_recode_fields_raise(fields_in_metadata):
             assert field in fields_in_metadata
 
 
-def test_crm_codes(seed_data_path):
-    crm_codes = pd.read_csv(f"{seed_data_path}/seed_crm_codes.csv")
-
+@pytest.mark.skip(reason="may not test this yet, was used to print CRM metadata")
 @pytest.mark.parametrize("dataset_name", ["dcp_projects", "dcp_projectbbls"])
 def test_recode_values(all_fields_metadata, dataset_name):
     fields_to_lookup, _ = get_fields(dataset_name)
-# def test_recode_values(all_fields_metadata):
-#     fields_to_lookup, _ = (["dcp_applicanttype"], ["applicant_type"])
 
     for field in fields_to_lookup:
         print(f"\n\nField name: {field}")

--- a/zap.sh
+++ b/zap.sh
@@ -28,7 +28,8 @@ case $1 in
             $tablename \
             $FILEPATH \
             schemas/$dataset.json
-        
+    ;;
+    upload_recoded_bq )
         # recoded version
         recoded_filename="${dataset}_after_recode.csv"
         FILEPATH=gs://zap-crm-export/datasets/$dataset/$VERSION/${dataset}_recoded.csv

--- a/zap.sh
+++ b/zap.sh
@@ -5,11 +5,10 @@ case $1 in
         python3 -m src.runner $2
     ;;
     upload_bq )
-        # only archives CRM and recoded version, not the subest for Open Data
+        # only archives CRM and recoded versions, not the subest for Open Data
         dataset=$2
         VERSION=${3:-$VERSION}
         location=US
-
         # crm version
         FILEPATH=gs://zap-crm-export/datasets/$dataset/$VERSION/$dataset.csv
         tablename=$dataset.$VERSION
@@ -30,6 +29,10 @@ case $1 in
             schemas/$dataset.json
     ;;
     upload_recoded_bq )
+        # only archives CRM and recoded versions, not the subest for Open Data
+        dataset=$2
+        VERSION=${3:-$VERSION}
+        location=US
         # recoded version
         recoded_filename="${dataset}_after_recode.csv"
         FILEPATH=gs://zap-crm-export/datasets/$dataset/$VERSION/${dataset}_recoded.csv

--- a/zap.sh
+++ b/zap.sh
@@ -5,12 +5,38 @@ case $1 in
         python3 -m src.runner $2
     ;;
     upload_bq )
-        location=US
+        # only archives CRM and recoded version, not the subest for Open Data
         dataset=$2
         VERSION=${3:-$VERSION}
-        tablename=$dataset.$VERSION
+        location=US
+
+        # crm version
         FILEPATH=gs://zap-crm-export/datasets/$dataset/$VERSION/$dataset.csv
+        tablename=$dataset.$VERSION
+        echo "Archving non-visible version ${dataset} ${VERSION} to ${tablename}..."
+
         gsutil cp .output/$dataset/$dataset.csv $FILEPATH
+        bq show $dataset || bq mk --location=$location --dataset $dataset
+        bq show $tablename || bq mk $tablename
+        bq load \
+            --location=$location\
+            --source_format=CSV\
+            --quote '"' \
+            --skip_leading_rows 1\
+            --replace\
+            --allow_quoted_newlines\
+            $tablename \
+            $FILEPATH \
+            schemas/$dataset.json
+        
+        # recoded version
+        recoded_filename="${dataset}_after_recode.csv"
+        FILEPATH=gs://zap-crm-export/datasets/$dataset/$VERSION/${dataset}_recoded.csv
+        VERSION_RECODED="${VERSION}_recoded"
+        tablename=$dataset.$VERSION_RECODED
+        echo "Archving recoded version ${dataset} ${VERSION_RECODED} to ${tablename}..."
+
+        gsutil cp .cache/$dataset/$recoded_filename $FILEPATH
         bq show $dataset || bq mk --location=$location --dataset $dataset
         bq show $tablename || bq mk $tablename
         bq load \

--- a/zap.sh
+++ b/zap.sh
@@ -50,9 +50,9 @@ case $1 in
             --skip_leading_rows 1\
             --replace\
             --allow_quoted_newlines\
+            --autodetect\
             $tablename \
-            $FILEPATH \
-            schemas/$dataset.json
+            $FILEPATH
     ;;
     upload_do )
         dataset=$2


### PR DESCRIPTION
## changes
- fix bug in passing along `version` as a github action step output in `GITHUB_OUTPUT`
- add some tests
- archive recoded open datasets to BigQuery after their records are limited for Open Data
  - uses `.cache/DATASET_after_recode.csv`, which is generate in between `.output/DATASET.csv` and `.output/DATASET_visible.csv`

## notes
- there are less rows in the recoded outputs (2,320 less out of 34,695 total from `.output/DATASET.csv`) due to the current logic for open datasets (`dcp_projects`, `dcp_projectbbls`) in `runner.py`:
  1. create a table of source CRM data called `dataname`
  2. create a table `from dataname where dcp_visibility = '717170003'` as `dataname_visible` and rename columns
  3. recode the `dataname_visible` table
  4. export `dataname_visible`
- the recode should take place before the tables are created, but the current code is too complex to quickly make this change

## tests
- [Weekly Export run](https://github.com/NYCPlanning/db-zap-opendata/actions/runs/5093743220/jobs/9156724908) on this branch with the latest changes
- screenshot of tables in bigquery
  - <img width="204" alt="image" src="https://github.com/NYCPlanning/db-zap-opendata/assets/7444289/d48efe7b-6057-4b3f-80bd-877eee6dba56">
